### PR TITLE
Update default container behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL vendor=neon.ai \
 ENV OVOS_CONFIG_BASE_FOLDER neon
 ENV OVOS_CONFIG_FILENAME diana.yaml
 ENV XDG_CONFIG_HOME /config
+ENV XDG_DATA_HOME /data
 COPY docker_overlay/ /
 
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ MQ:
 For example, if your configuration resides in `~/.config`:
 ```shell
 export CONFIG_PATH="/home/${USER}/.config"
-docker run -v ${CONFIG_PATH}:/config neon_metrics_connector
+export DATA_PATH="/home/${USER}/metrics"
+docker run -v ${CONFIG_PATH}:/config -v ${DATA_PATH}:/data neon_metrics_connector
 ```
 > Note: If connecting to a local MQ server, you may need to specify `--network host`


### PR DESCRIPTION
# Description
Add default `XDG_DATA_HOME` to `/data` in Dockerfile for simpler k8s deployment
Update README docker example to save metrics on the host system

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->